### PR TITLE
Only require actual twitter credentials in production.

### DIFF
--- a/config/initializers/application_twitter_id.rb
+++ b/config/initializers/application_twitter_id.rb
@@ -1,11 +1,26 @@
-Rails.application.config.application_twitter_id =
-  if Rails.env.test?
-    "FAKE_TWITTER_ID"
+class TwitterCredentials
+  if Rails.env.production?
+    CONSUMER_KEY = ENV.fetch("TWITTER_CONSUMER_KEY")
+    CONSUMER_SECRET = ENV.fetch("TWITTER_CONSUMER_SECRET")
+    ACCESS_TOKEN = ENV.fetch("TWITTER_ACCESS_TOKEN")
+    ACCESS_TOKEN_SECRET = ENV.fetch("TWITTER_ACCESS_TOKEN_SECRET")
+    def self.twitter_uid
+      Twitter::REST::Client.new(
+        consumer_key: TwitterCredentials::CONSUMER_KEY,
+        consumer_secret: TwitterCredentials::CONSUMER_SECRET,
+        access_token: TwitterCredentials::ACCESS_TOKEN,
+        access_token_secret: TwitterCredentials::ACCESS_TOKEN_SECRET,
+      ).user.id.to_s
+    end
   else
-    Twitter::REST::Client.new(
-      consumer_key: ENV.fetch("TWITTER_CONSUMER_KEY"),
-      consumer_secret: ENV.fetch("TWITTER_CONSUMER_SECRET"),
-      access_token: ENV.fetch("TWITTER_ACCESS_TOKEN"),
-      access_token_secret: ENV.fetch("TWITTER_ACCESS_TOKEN_SECRET"),
-    ).user.id.to_s
+    CONSUMER_KEY = "FAKE_TWITTER_CONSUMER_KEY"
+    CONSUMER_SECRET = "FAKE_TWITTER_CONSUMER_SECRET"
+    ACCESS_TOKEN = "FAKE_TWITTER_ACCESS_TOKEN"
+    ACCESS_TOKEN_SECRET = "FAKE_TWITTER_ACCESS_TOKEN_SECRET"
+    def self.twitter_uid
+      "FAKE_TWITTER_UID"
+    end
   end
+end
+
+Rails.application.config.application_twitter_id = TwitterCredentials.twitter_uid

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,7 +15,7 @@ Devise.setup do |config|
   # only the current scope. By default, Devise signs out all scopes.
   # config.sign_out_all_scopes = true
 
-  config.omniauth :twitter, ENV.fetch('TWITTER_CONSUMER_KEY'), ENV.fetch('TWITTER_CONSUMER_SECRET')
+  config.omniauth :twitter, TwitterCredentials::CONSUMER_KEY, TwitterCredentials::CONSUMER_SECRET
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/lib/twitter_updater.rb
+++ b/lib/twitter_updater.rb
@@ -1,10 +1,10 @@
 class TwitterUpdater < Struct.new(:consumer_key, :consumer_secret, :access_token, :access_token_secret)
   def self.authenticated
     new(
-      ENV.fetch("TWITTER_CONSUMER_KEY"),
-      ENV.fetch("TWITTER_CONSUMER_SECRET"),
-      ENV.fetch("TWITTER_ACCESS_TOKEN"),
-      ENV.fetch("TWITTER_ACCESS_TOKEN_SECRET")
+      TwitterCredentials::CONSUMER_KEY,
+      TwitterCredentials::CONSUMER_SECRET,
+      TwitterCredentials::ACCESS_TOKEN,
+      TwitterCredentials::ACCESS_TOKEN_SECRET
     )
   end
 

--- a/spec/features/view_a_conference_spec.rb
+++ b/spec/features/view_a_conference_spec.rb
@@ -19,9 +19,5 @@ RSpec.feature "Conferences", :vcr, :js do
     visit root_path
     click_on conference.name
     expect(page).to have_content conference.description
-    expect(page).to have_css '#twitter-widget-0'
-    within_frame('twitter-widget-0') do
-      expect(page).to have_content "just setting up my twttr"
-    end
   end
 end

--- a/spec/lib/twitter_updater_spec.rb
+++ b/spec/lib/twitter_updater_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe TwitterUpdater, :vcr do
 
     it 'returns a configured twitter updater' do
       expect(updater.to_h).to eq(
-        consumer_key: 'twitter_consumer_key',
-        consumer_secret: 'twitter_consumer_secret',
-        access_token: 'twitter_access_token',
-        access_token_secret: 'twitter_access_token_secret',
+        consumer_key: TwitterCredentials::CONSUMER_KEY,
+        consumer_secret: TwitterCredentials::CONSUMER_SECRET,
+        access_token: TwitterCredentials::ACCESS_TOKEN,
+        access_token_secret: TwitterCredentials::ACCESS_TOKEN_SECRET,
       )
     end
   end


### PR DESCRIPTION
The rest of the time, use fake strings and never attempt to actually contact twitter.

More explanation:
This issue https://github.com/minifast/conference-opportunities/issues/6 explains that currently, we require the twitter environment variables be set, even in tests. That sucks though, because it means circle CI builds on forks (e.g. pull requests) will always fail.

This PR removes our tests' dependencies on environment variables, and fixes an issue where we were actually calling out to twitter during a test.
