### PR TITLE
Specs refactor

### DIFF
--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ConferencesController, type: :controller do
   end
 
   describe 'GET #index' do
-    let!(:conference) { create :conference, :approved }
+    let!(:conferences) { create_list :conference, 3, :approved }
 
     subject(:make_request) { get :index }
 
@@ -39,7 +39,7 @@ RSpec.describe ConferencesController, type: :controller do
 
     it 'assigns all the approved conferences' do
       make_request
-      expect(assigns(:conferences).map(&:conference)).to eq([conference])
+      expect(assigns(:conferences).map(&:conference)).to match_array conferences
     end
   end
 end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe ConferencesController, type: :controller do
   describe 'GET #show' do
+    let(:conference) { create :conference }
 
     subject(:make_request) { get :show, params: { id: conference } }
-    let(:conference) { create :conference }
 
     context 'when requested conference is approved' do
       before { conference.update!(approved_at: 2.hours.ago) }
@@ -31,15 +31,19 @@ RSpec.describe ConferencesController, type: :controller do
   end
 
   describe 'GET #index' do
-    let!(:conferences) { create_list :conference, 3, :approved }
+    let!(:non_approved_conference) { create :conference }
+    let!(:approved_conferences) { create_list :conference, 3, :approved }
 
     subject(:make_request) { get :index }
 
     it { is_expected.to be_success }
 
-    it 'assigns all the approved conferences' do
-      make_request
-      expect(assigns(:conferences).map(&:conference)).to match_array conferences
+    context 'when listing conferences' do
+      subject { assigns(:conferences).map(&:conference) }
+
+        before { get :index }
+        it { is_expected.not_to include non_approved_conference }
+        it { is_expected.to match_array approved_conferences }
     end
   end
 end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ConferencesController, type: :controller do
   describe 'GET #show' do
 
     subject(:make_request) { get :show, params: { id: conference } }
-    let(:conference) { FactoryGirl.create :conference }
+    let(:conference) { create :conference }
 
     context 'when requested conference is approved' do
       before { conference.update!(approved_at: 2.hours.ago) }
@@ -31,7 +31,7 @@ RSpec.describe ConferencesController, type: :controller do
   end
 
   describe 'GET #index' do
-    let!(:conference) { FactoryGirl.create(:conference, :approved) }
+    let!(:conference) { create :conference, :approved }
 
     subject(:make_request) { get :index }
 

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -18,14 +18,16 @@ RSpec.describe ConferencesController, type: :controller do
     end
 
     context 'when the conference is not approved' do
-      it { expect { make_request }.to raise_error(Pundit::NotAuthorizedError) }
+      it { expect { make_request }
+        .to raise_error(Pundit::NotAuthorizedError) }
     end
 
     context 'when the requested conference does not exist' do
       before { conference.destroy! }
 
       it 'raises a not found exception' do
-        expect { make_request }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { make_request }
+          .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -2,37 +2,30 @@ require 'rails_helper'
 
 RSpec.describe ConferencesController, type: :controller do
   describe 'GET #show' do
-    def make_request(id)
-      get :show, params: {id: id}
-    end
+
+    subject(:make_request) { get :show, params: { id: conference } }
+    let(:conference) { FactoryGirl.create :conference }
 
     context 'when requested conference is approved' do
-      let!(:conference) { FactoryGirl.create(:conference, :approved, twitter_handle: 'fooconf') }
+      before { conference.update!(approved_at: 2.hours.ago) }
 
-      it 'is successful' do
-        make_request('fooconf')
-        expect(response).to be_success
-      end
+      it { is_expected.to be_success }
 
       it 'assigns the conference' do
-        make_request('fooconf')
-        expect(assigns(:conference)).to be
+        make_request
+        expect(assigns(:conference).class).to be ConferencePresenter
       end
     end
 
     context 'when the conference is not approved' do
-      let!(:conference) { FactoryGirl.create(:conference, twitter_handle: 'fooconf') }
-
-      it 'redirects to the home page' do
-        expect { make_request('fooconf') }.
-          to raise_error(Pundit::NotAuthorizedError)
-      end
+      it { expect { make_request }.to raise_error(Pundit::NotAuthorizedError) }
     end
 
     context 'when the requested conference does not exist' do
+      before { conference.destroy! }
+
       it 'raises a not found exception' do
-        expect { make_request('notaconf') }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect { make_request }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
@@ -40,14 +33,9 @@ RSpec.describe ConferencesController, type: :controller do
   describe 'GET #index' do
     let!(:conference) { FactoryGirl.create(:conference, :approved) }
 
-    def make_request
-      get :index
-    end
+    subject(:make_request) { get :index }
 
-    it 'returns http success' do
-      make_request
-      expect(response).to be_success
-    end
+    it { is_expected.to be_success }
 
     it 'assigns all the approved conferences' do
       make_request

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
Hello!
I've implemented some of the practices suggested by [Better Specs](http://betterspecs.org/) in order to make specs more readable.

The changes have been made in `conferences_controller_spec`.
If accepted, I could apply the same concepts to the other files too! :wink: 

Implemented concepts include:
- [Test all possible cases](http://betterspecs.org/#all): implemented example of non approved conference on index, to make sure only approved ones are listed. 
- [Use subject](http://betterspecs.org/#subject): There was a function called `make_request`. I changed it to a subject, so the expectations examples could be called using a one-liner syntax.

Besides better specs guidelines:
- Added FactoryGirl configuration to the test suits, so specs can call `create :conference` instead of `FactoryGirl.create :conference`
- Created a list of approved conferences on the index spec, so the test really checks if all approved are listed.
